### PR TITLE
Fixed example of name change

### DIFF
--- a/views/prototype/apply/previous-names.html
+++ b/views/prototype/apply/previous-names.html
@@ -19,7 +19,7 @@
 {{$form}}
 
 {{#values.change-name}}
-  <p>Tell us the name on {{> partials-applicant-your-their}} {{> partials-information-compared-to-document}} and any other names {{> partials-applicant-you-they}} have been known by. For example a maiden name, a previous married name or a name which you changed for another reason.</p>
+  <p>Tell us the name on {{> partials-applicant-your-their}} {{> partials-information-compared-to-document}} and any other names {{> partials-applicant-you-they}} have been known by. For example a maiden name, a previous married name or a name you were given at birth and changed later.</p>
 
   <input type="hidden" name="previous-name" value="true" required="true">
 {{/values.change-name}}


### PR DESCRIPTION
If the user selected 'No my name has changed' on /apply/name then the examples of name changes were incorrect on /apply/previous-names. This change fixes that hint text.