### PR TITLE
Email content

### DIFF
--- a/static/emails/lost-stolen/confirming-your-identity.html
+++ b/static/emails/lost-stolen/confirming-your-identity.html
@@ -48,10 +48,10 @@ li {
                         </p>
                         <p>Charlotte Moore has provided details to help us confirm your identity. We’re checking these details.</p>
 
-                        <p>We’ll update tracking and send you an email when your passport is on it’s way.</p>
+                        <p>We’ll update tracking and send you an email when your passport is on its way.</p>
 
                         <h2>Track your application</h2>
-                          <p>You need your application reference PEX 896 345 1083 to sign in:<br>
+                          <p>You can track your application at:<br>
                           <a href="/csig/user?status=send-passport">https://www.passport.service.gov.uk/track.</a></p>
 
                         Please don’t reply to this email - it’s an automatic message from an unmonitored account.

--- a/static/emails/lost-stolen/paper-referee-no-docs-reminder-1-and-14-days.html
+++ b/static/emails/lost-stolen/paper-referee-no-docs-reminder-1-and-14-days.html
@@ -36,7 +36,7 @@ li {
                 <tr>
                     <td width="75%">
 
-                        <code style="background-color: #eee; padding: 0 3px;"><span>Subject: </span>Subject line will go here</code>
+                        <code style="background-color: #eee; padding: 0 3px;"><span>Subject: </span>Send us the form confirming your identity</code>
 
                         <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;">
                           Dear Charlotte Moore,
@@ -46,17 +46,13 @@ li {
                             Application reference: PEX 123 456 7890<br/>
                         </p>
 
-                        <p>Remember to send us your documents. We can't complete your application without them.</p>
+                        <p>Remember to send us the form confirming your identity. We can't complete your application without it.</p>
 
                         <h2>What you need to do</h2>
 
-                        <h3>Send us your documents</h3>
+                        <h3>Send us your form</h3>
 
-                        <p>Sign in to check which documents to send:</p>
-
-                        <p>{{URL}}</p>
-
-                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. Send them to:</p>
+                        <p>Use a strong envelope that is the right size for your form. You can use standard post or special delivery. Send it to:</p>
 
                         <p>HM Passport Office <br>
                             Ref: PEX 123 456 789 <br>
@@ -65,13 +61,13 @@ li {
                             Peterborough <br>
                             PE1 1QG</p>
 
-                        <p>Find out how to send your documents if you're applying as part of a family or couple at: <br>
-                        https://www.passport.service.gov.uk/help/multiple-documents-guidance
+                        <p>Find out how to send your form if you're applying as part of a family or couple at: <br>
+                        <a href="">https://www.passport.service.gov.uk/help/multiple-documents-guidance</a>
                         </p>    
 
-                        <h2>If you've already sent them</h2>
+                        <h2>If you've already sent it</h2>
 
-                        <p>If you sent your documents in the last 4 working days, ignore this email. We'll let you know when we have them.</p>
+                        <p>If you sent your form in the last 4 working days, ignore this email. We'll let you know when we have it.</p>
 
                         <h2>Track your application</h2>
 

--- a/static/emails/lost-stolen/paper-referee-no-docs-reminder-28-days.html
+++ b/static/emails/lost-stolen/paper-referee-no-docs-reminder-28-days.html
@@ -36,7 +36,7 @@ li {
                 <tr>
                     <td width="75%">
 
-                        <code style="background-color: #eee; padding: 0 3px;"><span>Subject: </span>Subject line will go here</code>
+                        <code style="background-color: #eee; padding: 0 3px;"><span>Subject: </span>You must send us the form confirming your identity</code>
 
                         <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;">
                           Dear Charlotte Moore,
@@ -46,32 +46,29 @@ li {
                             Application reference: PEX 123 456 7890<br/>
                         </p>
 
-                        <p>Remember to send us your documents. We can't complete your application without them.</p>
+                        <p>Your application will be withdrawn if we don't receive the form confirming your identity by 12 April 2018. Fees can't be refunded.</p>
 
                         <h2>What you need to do</h2>
 
-                        <h3>Send us your documents</h3>
+                        <h3>Send us your form now</h3>
 
-                        <p>Sign in to check which documents to send:</p>
-
-                        <p>{{URL}}</p>
-
-                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. Send them to:</p>
+                        <p>Use a strong envelope that is the right size for your form. You can use standard post or special delivery. Send it to:</p>
 
                         <p>HM Passport Office <br>
-                            Ref: PEX 123 456 789 <br>
+                            Red: PEX 123 456 789 <br>
                             Aragon Court <br>
                             Northminster Road <br>
                             Peterborough <br>
                             PE1 1QG</p>
 
-                        <p>Find out how to send your documents if you're applying as part of a family or couple at: <br>
-                        https://www.passport.service.gov.uk/help/multiple-documents-guidance
+                        <p>Find out how to send your form if you're applying as part of a family or couple at: <br>
+                        <a href="">https://www.passport.service.gov.uk/help/multiple-documents-guidance</a>
                         </p>    
 
-                        <h2>If you've already sent them</h2>
 
-                        <p>If you sent your documents in the last 4 working days, ignore this email. We'll let you know when we have them.</p>
+                        <h2>If you've already sent it</h2>
+
+                        <p>If you sent your form in the last 4 working days, ignore this email. We'll let you know when we have it.</p>
 
                         <h2>Track your application</h2>
 

--- a/views/notifications.html
+++ b/views/notifications.html
@@ -92,6 +92,8 @@
     <li><a href="static/emails/lost-stolen/confirming-your-identity.html">Confirming your identity</a></li>
     <li><a href="static/emails/lost-stolen/application-approved.html">Application approved</a></li>
     <li><a href="static/emails/lost-stolen/passport-on-its-way.html">Passport printed</a></li>
+    <li><a href="static/emails/lost-stolen/paper-referee-no-docs-reminder-1-and-14-days.html">Reminder 1 & 14 days (paper form, no documents)</a></li>
+    <li><a href="static/emails/lost-stolen/paper-referee-no-docs-reminder-28-days.html">Reminder 28 days (paper form, no documents)</a></li>
   </ul>
 
   <h3>Change of name</h3>


### PR DESCRIPTION
* Edited the 1/14 day reminder email to match production version. Added the line about multiple applications.
* Edited the 'confirming your identity' email for lost and stolen to match production version and fix a typo (which will be fixed in an upcoming Thundercats story).
* Added paper referee, no docs versions of the 1/14 day and 28 day reminders.
* Updated the notifications index page.  