### PR TITLE
Last minute lab changes

### DIFF
--- a/views/prototype/apply/parent-1-euss-status.html
+++ b/views/prototype/apply/parent-1-euss-status.html
@@ -1,9 +1,9 @@
 {{< layout}}
 
-{{$pageTitle}}Did the mother or parent 1 have EU settled status when the applicant was born?{{/pageTitle}}
+{{$pageTitle}}Did the mother or parent 1 have EU settled status when the you were born?{{/pageTitle}}
 
 {{$header}}
-    <h1>Did the mother or parent 1 have EU settled status when the applicant was born?</h1>
+    <h1>Did the mother or parent 1 have EU settled status when you were born?</h1>
 {{/header}}
 
 {{$content}}

--- a/views/prototype/apply/parent-2-euss-status.html
+++ b/views/prototype/apply/parent-2-euss-status.html
@@ -1,9 +1,9 @@
 {{< layout}}
 
-{{$pageTitle}}Did the father or parent 2 have EU settled status when the applicant was born?{{/pageTitle}}
+{{$pageTitle}}Did the father or parent 2 have EU settled status when you were born?{{/pageTitle}}
 
 {{$header}}
-    <h1>Did the father or parent 2 have EU settled status when the applicant was born?</h1>
+    <h1>Did the father or parent 2 have EU settled status when you were born?</h1>
 {{/header}}
 
 {{$content}}

--- a/views/prototype/filter/either-parents-euss.html
+++ b/views/prototype/filter/either-parents-euss.html
@@ -9,7 +9,7 @@
 
 {{$content}}
 
-<p>They'll only have settled status if they successfully applied to the EU Settlement Scheme.</p>
+<p>They'll only have settled status if they successfully applied to the <a href="https://www.gov.uk/settled-status-eu-citizens-families" target="_blank">EU Settlement Scheme</a>.</p>
 
 {{< hmpo-partials-form}}
 {{$form}}

--- a/views/prototype/intro/what-you-need.html
+++ b/views/prototype/intro/what-you-need.html
@@ -44,7 +44,7 @@
     </ul>
 
     {% if values['born-after-2018'] and not values['naturalisation-registration-certificate'] and values['either-euss-status'] and not values['passport-before']%}
-        <p>If the parent had <a href="https://www.gov.uk/settled-status-eu-citizens-families" target="_blank">EU settled status</a> at the time of the applicant's birth, you'll also need the reference number from either:</p>
+        <p>If the parent had EU settled status at the time of the applicant's birth, you'll also need the reference number from either:</p>
         <ul class="list list-bullet">
             <li>the letter or email confirming their settled status</li>
             <li>their passport, identity card or biometric residence permit – the one they used to apply for EU settled status, or a more recent one if they've updated it on the settled status online service</li> 


### PR DESCRIPTION
Moved the link to GOV.UK content on EUSS from "what you'll need" to filter page. It makes sense to have the link the first time EUSS is mentioned, otherwise the user will already have confirmed a parent had it before getting a link to find out more about it.

Changed question on EUSS status pages from "when the applicant was born" to "when you were born". The word applicant is used on the previous page, but otherwise the journey says "you" pretty much throughout when referring to the child who is getting a passport. It might be that "you" is confusing, but if so then we should look at fixing that – so we can learn from using it to fit (most of) the rest of the journey.