### PR TITLE
Added 'no docs and no referee' logic & content for adult lost and stolen

### DIFF
--- a/views/partials/how-to/how-to-lost-stolen.html
+++ b/views/partials/how-to/how-to-lost-stolen.html
@@ -27,11 +27,17 @@
               {% endif %}
             
           </li>
-          <li>
-            <span class="circle circle-step">3</span>
-            <h2>Ask someone to confirm your identity</h2>
-            <p style="margin-left:32px;">They can <a href="help/confirming-your-identity" target="_blank">confirm your identity online</a> without a printed photo.</p>
-          </li>
+
+          {# No referee for adult lost and stolen #}
+
+          {% if values['applicant-age'] < 16 %}
+            <li>
+              <span class="circle circle-step">3</span>
+              <h2>Ask someone to confirm your identity</h2>
+              <p style="margin-left:32px;">They can <a href="help/confirming-your-identity" target="_blank">confirm your identity online</a> without a printed photo.</p>
+            </li>
+          {% endif %}
+        
         </ul>
         {{/nunjucks}}
         {{#input-submit}}{{/input-submit}}

--- a/views/prototype/apply/confirmation.html
+++ b/views/prototype/apply/confirmation.html
@@ -14,85 +14,84 @@
         {{#nunjucks}}
 
             <p>{{ "Your application has been saved and we're now processing it." if values['lost-stolen-no-docs'] else "Your application has been saved." }}
-            <br>Application reference <strong>PEX 319 825 680X</strong></p>
+            
+            {# Don't show application reference in first paragraph for lost and stolen with no docs and no referee #}
 
-            <h1>What you need to do</h1>
-            <p>Before we can work on your application, you need to:</p>
+            {% if not (not values['change-of-name-reason'] and values['lost-stolen-no-docs'] and values['application-type'] === 'replacement-lost-or-stolen-adult') %}
+                
+                <br>Application reference <strong>PEX 319 825 680X</strong></p>
 
+            {% endif %}
 
-            {#
-                Main content
-            #}
+                {#
+                    Main content
+                #}
 
-            {# 12–15 Renewals, Adult Renewals, Replacements Damaged Child 12–15s, Replacements Damaged Adult #}
-            {% if values['application-type'] === 'renew-child-12-15' or
-                  values['application-type'] === 'renew-adult' or
-                  values['application-type'] === 'replacement-damaged-child-12-15' or
-                  values['application-type'] === 'replacement-damaged-adult' %}
+            {# LSR no docs no referee #}
+            {% if not values['change-of-name-reason'] and values['lost-stolen-no-docs'] and values['application-type'] === 'replacement-lost-or-stolen-adult' %}
 
-                {% if values['change-of-name-reason'] or values['application-for-someone-else'] %}
-                    <h2> Send us your documents </h2>
-                    <p><a href="./docs-renew?status=confirm-documents" target="_blank">Check what you need to send</a></p>
-                {% else %}
-                    <h2> Send us your old passport </h2>
-                    <p>Check if you need to send any <a href="./docs-renew?status=confirm-documents" target="_blank">additional documents</a>.</p>
-                {% endif %}
+                <h1>Track your application</h1>
+                <p>You'll need your application reference: PEX 319 825 680X<br>
+                <a href='https://www.passport.service.gov.uk/track'>https://www.passport.service.gov.uk/track</a></p>
 
-                <p>Use a strong envelope that is the right size for your documents. You do not need to include a covering letter.</p>
+                <a href="" class="button">Give feedback</a><br><br>
 
-                <p>You can use standard post or special delivery.</p>
+            {# All application types except LSR no docs no referee #}
 
-                <p>HM Passport Office<br>
-                UK-DAP<br>
-                PEX 318 437 555X<br>
-                Aragon Court<br>
-                Northminster Road<br>
-                Peterborough<br>
-                PE1 1QG</p>
+            {% else %}
 
-                <details>
-                    <summary>
-                        <span class="summary">If you're applying as part of a family or couple</span>
-                    </summary>
-                    <div class="panel panel-border-narrow">
-                        <p>Find out how to send your documents if you're <a href="../help/group-applications" target="_blank">applying as part of a <br>family or couple</a>.</p>
-                    </div>
-                </details>
+                <h1>What you need to do</h1>
+                <p>Before we can work on your application, you need to:</p>
 
-                <h2>Track your application</h2>
-                {% if values['change-of-name-reason'] or values['application-for-someone-else'] %}
-                    <p>You'll need your application reference: PEX 319 825 680X <br><a href="/tracking?status=send-us-your-docs">https://www.passport.service.gov.uk/track</a></p>
-                {% else %}
-                    <p>You'll need your application reference: PEX 319 825 680X <br><a href="/tracking?status=waiting-for-old">https://www.passport.service.gov.uk/track</a></p>
-                {% endif %}
+                {# 12–15 Renewals, Adult Renewals, Replacements Damaged Child 12–15s, Replacements Damaged Adult #}
+                {% if values['application-type'] === 'renew-child-12-15' or
+                    values['application-type'] === 'renew-adult' or
+                    values['application-type'] === 'replacement-damaged-child-12-15' or
+                    values['application-type'] === 'replacement-damaged-adult' %}
 
-            {# 0–11 Renewals, Replacements Damaged Child 0–11s, FTC, FTA, Hidden FTA (Old Blue) #}
-            {% elif values['application-type'] === 'renew-child-0-11' or
-                    values['application-type'] === 'replacement-damaged-child-0-11' or
-                    values['application-type'] === 'first-child' or
-                    values['application-type'] === 'first-adult' or
-                    values['application-type'] === 'old-blue' %}
+                    {% if values['change-of-name-reason'] or values['application-for-someone-else'] %}
+                        <h2> Send us your documents </h2>
+                        <p><a href="./docs-renew?status=confirm-documents" target="_blank">Check what you need to send</a></p>
+                    {% else %}
+                        <h2> Send us your old passport </h2>
+                        <p>Check if you need to send any <a href="./docs-renew?status=confirm-documents" target="_blank">additional documents</a>.</p>
+                    {% endif %}
 
-                <h2>1. Ask someone to confirm your identity</h2>
-                <p>Sign in to check who can do this and provide their details. You'll need your application reference: PEX 319 825 680X</p>
+                    <p>Use a strong envelope that is the right size for your documents. You do not need to include a covering letter.</p>
 
-                <h2>2. Get your documents ready</h2>
-                <p>We can only receive documents after your identity has been confirmed. This includes anyone you're <a href="../help/group-applications" target="_blank">applying with as part of a family or couple</a>.</p>
+                    <p>You can use standard post or special delivery.</p>
 
-                <p>We'll let you know when and where to send them.</p>
+                    <p>HM Passport Office<br>
+                    UK-DAP<br>
+                    PEX 318 437 555X<br>
+                    Aragon Court<br>
+                    Northminster Road<br>
+                    Peterborough<br>
+                    PE1 1QG</p>
 
-            {# Lost or Stolen Child 0–11s, Lost or Stolen Child 12–15s, Lost or Stolen Adult #}
-            {% elif values['application-type'] === 'replacement-lost-or-stolen-child-0-11' or
-                    values['application-type'] === 'replacement-lost-or-stolen-child-12-15' or
-                    values['application-type'] === 'replacement-lost-or-stolen-adult' %}
+                    <details>
+                        <summary>
+                            <span class="summary">If you're applying as part of a family or couple</span>
+                        </summary>
+                        <div class="panel panel-border-narrow">
+                            <p>Find out how to send your documents if you're <a href="../help/group-applications" target="_blank">applying as part of a <br>family or couple</a>.</p>
+                        </div>
+                    </details>
 
-                {# LSR no docs #}
-                {% if not values['change-of-name-reason'] and values['lost-stolen-no-docs'] %}
-                <h2>Ask someone to confirm your identity</h2>
-                <p>Sign in to check who can do this and provide their details. You'll need your application reference: PEX 319 825 680X</p>
+                    <h2>Track your application</h2>
+                    {% if values['change-of-name-reason'] or values['application-for-someone-else'] %}
+                        <p>You'll need your application reference: PEX 319 825 680X <br><a href="/tracking?status=send-us-your-docs">https://www.passport.service.gov.uk/track</a></p>
+                    {% else %}
+                        <p>You'll need your application reference: PEX 319 825 680X <br><a href="/tracking?status=waiting-for-old">https://www.passport.service.gov.uk/track</a></p>
+                    {% endif %}
 
-                {# LSR with docs #}
-                {% else %}
+                {# 0–11 Renewals, Replacements Damaged Child 0–11s, FTC, FTA, Hidden FTA (Old Blue) #}
+                {% elif values['application-type'] === 'renew-child-0-11' or
+                        values['application-type'] === 'replacement-damaged-child-0-11' or
+                        values['application-type'] === 'first-child' or
+                        values['application-type'] === 'first-adult' or
+                        values['application-type'] === 'old-blue' %}
+
                     <h2>1. Ask someone to confirm your identity</h2>
                     <p>Sign in to check who can do this and provide their details. You'll need your application reference: PEX 319 825 680X</p>
 
@@ -100,45 +99,67 @@
                     <p>We can only receive documents after your identity has been confirmed. This includes anyone you're <a href="../help/group-applications" target="_blank">applying with as part of a family or couple</a>.</p>
 
                     <p>We'll let you know when and where to send them.</p>
+
+                {# Lost or Stolen Child 0–11s, Lost or Stolen Child 12–15s, Lost or Stolen Adult #}
+                {% elif values['application-type'] === 'replacement-lost-or-stolen-child-0-11' or
+                        values['application-type'] === 'replacement-lost-or-stolen-child-12-15' or
+                        values['application-type'] === 'replacement-lost-or-stolen-adult' %}
+
+                    {# LSR no docs #}
+                    {% if not values['change-of-name-reason'] and values['lost-stolen-no-docs'] %}
+                    <h2>Ask someone to confirm your identity</h2>
+                    <p>Sign in to check who can do this and provide their details. You'll need your application reference: PEX 319 825 680X</p>
+
+                    {# LSR with docs #}
+                    {% else %}
+                        <h2>1. Ask someone to confirm your identity</h2>
+                        <p>Sign in to check who can do this and provide their details. You'll need your application reference: PEX 319 825 680X</p>
+
+                        <h2>2. Get your documents ready</h2>
+                        <p>We can only receive documents after your identity has been confirmed. This includes anyone you're <a href="../help/group-applications" target="_blank">applying with as part of a family or couple</a>.</p>
+
+                        <p>We'll let you know when and where to send them.</p>
+                    {% endif %}
+
                 {% endif %}
 
-            {% endif %}
 
+                {#
+                    Sign in and feedback
+                #}
 
-            {#
-                Sign in and feedback
-            #}
+                {# 12–15 Renewals, Adult Renewals, Replacements Damaged Child 12–15s, Replacements Damaged Adult #}
+                {% if values['application-type'] === 'renew-child-12-15' or
+                    values['application-type'] === 'renew-adult' or
+                    values['application-type'] === 'replacement-damaged-child-12-15' or
+                    values['application-type'] === 'replacement-damaged-adult' %}
 
-            {# 12–15 Renewals, Adult Renewals, Replacements Damaged Child 12–15s, Replacements Damaged Adult #}
-            {% if values['application-type'] === 'renew-child-12-15' or
-                  values['application-type'] === 'renew-adult' or
-                  values['application-type'] === 'replacement-damaged-child-12-15' or
-                  values['application-type'] === 'replacement-damaged-adult' %}
+                    <a href="" class="button">Give feedback</a><br><br>
 
-                <a href="" class="button">Give feedback</a><br><br>
+                {# 0–11 Renewals, Replacements Damaged Child 0–11s, FTC #}
+                {% elif values['application-type'] === 'renew-child-0-11' or
+                        values['application-type'] === 'replacement-damaged-child-0-11' or
+                        values['application-type'] === 'first-child' %}
 
-            {# 0–11 Renewals, Replacements Damaged Child 0–11s, FTC #}
-            {% elif values['application-type'] === 'renew-child-0-11' or
-                    values['application-type'] === 'replacement-damaged-child-0-11' or
-                    values['application-type'] === 'first-child' %}
-
-                <a href="/tracking/user/?csigtype=child" class="button">Sign in</a>
-
-            {# FTA, Hidden FTA (Old Blue) #}
-            {% elif values['application-type'] === 'first-adult' or
-                    values['application-type'] === 'old-blue' %}
-
-                <a href="/tracking/user" class="button">Sign in</a>
-
-            {# Lost or Stolen Child 0–11s, Lost or Stolen Child 12–15s, Lost or Stolen Adult #}
-            {% elif values['application-type'] === 'replacement-lost-or-stolen-child-0-11' or
-                    values['application-type'] === 'replacement-lost-or-stolen-child-12-15' or
-                    values['application-type'] === 'replacement-lost-or-stolen-adult' %}
-
-                {% if values['applicant-age'] < 16 %}
                     <a href="/tracking/user/?csigtype=child" class="button">Sign in</a>
-                {% else %}
+
+                {# FTA, Hidden FTA (Old Blue) #}
+                {% elif values['application-type'] === 'first-adult' or
+                        values['application-type'] === 'old-blue' %}
+
                     <a href="/tracking/user" class="button">Sign in</a>
+
+                {# Lost or Stolen Child 0–11s, Lost or Stolen Child 12–15s, Lost or Stolen Adult #}
+                {% elif values['application-type'] === 'replacement-lost-or-stolen-child-0-11' or
+                        values['application-type'] === 'replacement-lost-or-stolen-child-12-15' or
+                        values['application-type'] === 'replacement-lost-or-stolen-adult' %}
+
+                    {% if values['applicant-age'] < 16 %}
+                        <a href="/tracking/user/?csigtype=child" class="button">Sign in</a>
+                    {% else %}
+                        <a href="/tracking/user" class="button">Sign in</a>
+                    {% endif %}
+
                 {% endif %}
 
             {% endif %}


### PR DESCRIPTION
See https://collaboration.homeoffice.gov.uk/jira/browse/PEXRD-1081

For adults with lost or stolen passports:

* remove the mention of a referee from the 'how to apply' page
* just give tracking details on the confirmation page (since the user doesn't need to do anything)