### PR TITLE
Apply in Welsh page plus 'no covering letter' in various emails

### DIFF
--- a/static/emails/FTA/document-reminder-1-and-14-days.html
+++ b/static/emails/FTA/document-reminder-1-and-14-days.html
@@ -56,7 +56,9 @@ li {
 
                         <p>{{URL}}</p>
 
-                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. Send them to:</p>
+                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. You don't need to include a covering letter.</p> 
+                        
+                        <p>Send your documents to:</p>
 
                         <p>HM Passport Office <br>
                             Ref: PEX 123 456 789 <br>

--- a/static/emails/FTA/document-reminder-28-days.html
+++ b/static/emails/FTA/document-reminder-28-days.html
@@ -56,7 +56,9 @@ li {
 
                         <p>{{URL}}</p>
 
-                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. Send them to:</p>
+                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. You don't need to include a covering letter.</p> 
+                        
+                        <p>Send your documents to:</p>
 
                         <p>HM Passport Office <br>
                             Red: PEX 123 456 789 <br>

--- a/static/emails/con/application-received.html
+++ b/static/emails/con/application-received.html
@@ -56,7 +56,9 @@ li {
 
                         <p>{{URL}}</p>
 
-                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. Send them to:</p>
+                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. You don't need to include a covering letter.</p> 
+                        
+                        <p>Send your documents to:</p>
 
                         <p>HM Passport Office <br>
                             Red: PEX 123 456 789 <br>

--- a/static/emails/csig/csig-email-20.html
+++ b/static/emails/csig/csig-email-20.html
@@ -55,7 +55,9 @@ li {
                         <p>Sign in to check which documents to send:
                          <br><a href="/csig/user?status=send-docs">https://www.passport.service.gov.uk/track</a></p>
 
-                         <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. Send your documents to:</p>
+                        <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. You don't need to include a covering letter.</p> 
+                        
+                        <p>Send your documents to:</p>
 
                         <p>HM Passport Office<br>
                         Ref: PEX 896 345 1083<br>

--- a/static/emails/renewal/application-received.html
+++ b/static/emails/renewal/application-received.html
@@ -52,7 +52,9 @@ li {
 
                         <h3>Send us your old passport</h3>
 
-                        <p>Use a strong envelope that is the right size for your passport. You can use standard post or special delivery. Send it to:</p>
+                        <p>Use a strong envelope that is the right size for your passport. You can use standard post or special delivery. You don't need to include a covering letter.</p> 
+                        
+                        <p>Send your passport to:</p>
 
                         <p>HM Passport Office <br>
                             Red: PEX 123 456 789 <br>

--- a/static/emails/renewal/passport-reminder-1-and-14-days.html
+++ b/static/emails/renewal/passport-reminder-1-and-14-days.html
@@ -52,7 +52,9 @@ li {
 
                         <h3>Send us your old passport</h3>
 
-                        <p>Use a strong envelope that is the right size for your passport. You can use standard post or special delivery. Send it to:</p>
+                        <p>Use a strong envelope that is the right size for your passport. You can use standard post or special delivery. You don't need to include a covering letter.</p> 
+                        
+                        <p>Send your passport to:</p>
 
                         <p>HM Passport Office <br>
                             Red: PEX 123 456 789 <br>

--- a/static/emails/renewal/passport-reminder-28-days.html
+++ b/static/emails/renewal/passport-reminder-28-days.html
@@ -52,7 +52,9 @@ li {
 
                         <h3>Send us your old passport now</h3>
 
-                        <p>Use a strong envelope that is the right size for your passport. You can use standard post or special delivery. Send it to:</p>
+                        <p>Use a strong envelope that is the right size for your passport. You can use standard post or special delivery. You don't need to include a covering letter.</p> 
+                        
+                        <p>Send your passport to:</p>
 
                         <p>HM Passport Office <br>
                             Red: PEX 123 456 789 <br>

--- a/views/prototype/help/apply-in-welsh.html
+++ b/views/prototype/help/apply-in-welsh.html
@@ -1,48 +1,51 @@
 {{< layout}}
 
 {{$pageTitle}}
-    Apply in Welsh for a passport
+    Ymgeisio trwy gyfrwng y Gymraeg am basbort
 {{/pageTitle}}
 
 {{$header}}
-    <h1>Apply in Welsh for a passport</h1>
+    <h1>Ymgeisio trwy gyfrwng y Gymraeg am basbort</h1>
 {{/header}}
 
 {{$content}}
 
-    <p>To apply in Welsh you can:</p>
+    <p>Er mwyn ymgeisio trwy gyfrwng y Gymraeg, gallwch:</p>
 
     <ul class="list list-bullet">
-      <li>pick up application forms from a <a href="https://www.postoffice.co.uk/branch-finder">Post Office</a> in Wales</li>
-      <li>call the Passport Adviceline and ask us to send you the application forms</li>
+      <li>gasglu ffurflenni cais o <a href="https://www.postoffice.co.uk/branch-finder">Swyddfa’r Post yng Nghymru</a></li>
+      <li>ffonio’r Llinell Gyngor Pasbortau a gofyn i ni anfon y ffurflenni cais atoch</li>
     </ul>
 
-    <p>You can send your completed application by post or use the <a href="https://www.gov.uk/how-the-post-office-check-and-send-service-works">Post Office Check and Send service</a>.</p>
+    <p>Gallwch anfon eich cais wedi ei gwblhau trwy’r post neu ddefnyddio <a href="https://www.gov.uk/how-the-post-office-check-and-send-service-works">gwasanaeth Gwirio ac Anfon Swyddfa’r Post</a>.</p>
 
     <div class="panel panel-border-wide">
 
-        <p><strong>Passport Adviceline</strong>
-        <br>Telephone: 0300 222 0000
-        <br>From outside the UK: +44 (0)300 222 0000
-        <br>Textphone: 18001 0300 222 0222
-        <br>Monday to Friday, 8am to 8pm
-        <br>Weekends and public holidays, 9am to 5:30pm
-        <br><a href="https://www.gov.uk/call-charges">Find out about call charges</a>
+        <p><strong>Llinell Gyngor Pasbortau
+</strong>
+        <br>Ffôn: 0300 222 0000
+        <br>O’r tu allan i’r Deyrnas Unedig: +44 (0)300 222 0000
+        <br>Ffôn testun: 18001 0300 222 0222
+        <br>Dydd Llun i Ddydd Gwener, 8am i 8pm
+        <br>Penwythnosau a gwyliau cyhoeddus, 9am tan 5:30pm
+        <br><a href="https://www.gov.uk/call-charges">Dysgwch am gostau galwadau</a>
         </p>
 
     </div>
 
-    <h2>Discount on the application fee</h2>
+    <h2>Gostyngiad ar y ffi ymgeisio</h2>
 
-    <p>It isn't currently possible to apply online in Welsh, so you'll get a refund of £9.50. This is the same as the discount given for applying online in English.</p> 
+    <p>Nid yw’n bosibl ymgeisio trwy gyfrwng y Gymraeg ar-lein ar hyn o bryd, felly byddwch yn cael ad-daliad o £9.50. Mae hyn yn yr un faint â’r gostyngiad a roddir am ymgeisio ar-lein yn Saesneg.</p> 
 
-    <p>We'll give you the refund within 20 working days of approving your application.</p>
+    <p>Byddwn yn talu’r ad-daliad i chi cyn pen 20 diwrnod gwaith o gymeradwyo eich cais.</p>
 
-    <h2>Other ways to apply</h2>
+    <h2>Ffyrdd eraill o ymgeisio</h2>
 
-    <p>If you prefer, you can <a href="https://www.gov.uk/apply-renew-passport">apply online in English</a>.</p> 
+    <p>Pe byddai’n well gennych, gallwch <a href="https://www.gov.uk/apply-renew-passport">ymgeisio ar-lein yn Saesneg</a>.</p> 
 
-    <p>Use a different service if you <a href="https://www.gov.uk/get-a-passport-urgently">need your passport urgently</a>. You can use Welsh application forms for the Paper Premium or Fast Track services.</p>
+    <p>Defnyddiwch wasanaeth gwahanol os ydych chi <a href="https://www.gov.uk/get-a-passport-urgently">angen eich pasbort ar frys</a>. Gallwch ddefnyddio ffurflenni cais Cymraeg ar gyfer gwasanaethau Premiwm Papur neu Lwybr Cyflym.</p>
+
+    <a href="/" class="button">Close</a>
 
 {{/ content}}
 


### PR DESCRIPTION
These are just a few changes which I've been meaning to make:

* adding the Welsh language version of 'apply in Welsh' (there are a couple of formatting mistakes in production which I haven't replicated, like using an ordered list instead of an unordered one)
* telling users not to send a covering letter in various emails (https://collaboration.homeoffice.gov.uk/jira/browse/PEXRD-959)