### PR TITLE
Fixing surname validation so that my daughter and son can have a passport.

### DIFF
--- a/routes/prototype/apply/fields.js
+++ b/routes/prototype/apply/fields.js
@@ -135,7 +135,7 @@ module.exports = {
             'required',
             {
                 type: 'regex',
-                arguments: /^[A-Za-z .'-]+$/
+                arguments: /^[A-Za-z .'-í]+$/
             }
         ]
     },


### PR DESCRIPTION
Adding accented `i` so that my daughter and son can have a passport with their surname correctly spelled.

Went for the simplest implementation here, you might want to cover other accented vowels.